### PR TITLE
[semver-1.9.10] Add metric gauge for chaoskube annotation

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -229,6 +229,28 @@ var (
 			}),
 		},
 		{
+			Name: "kube_pod_chaoskube_enabled",
+			Type: metric.Gauge,
+			Help: "Describes whether the pod can be killed by chaoskube",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				var chaoskubeEnabled string
+				if p.Annotations["chaos.alpha.kubernetes.io/enabled"] == "true" {
+					chaoskubeEnabled = "true"
+				} else {
+					chaoskubeEnabled = "false"
+				}
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"pod_chaoskube_enabled"},
+							LabelValues: []string{chaoskubeEnabled},
+							Value:       boolFloat64(chaoskubeEnabled == "true"),
+						},
+					},
+				}
+			}),
+		},
+		{
 			Name: "kube_pod_status_scheduled_time",
 			Type: metric.Gauge,
 			Help: "Unix timestamp when pod moved into scheduled status",

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1504,6 +1504,63 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 			},
 		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "ns1",
+					Annotations: map[string]string{
+						"chaos.alpha.kubernetes.io/enabled": "true",
+					},
+				},
+				Spec: v1.PodSpec{},
+			},
+			Want: `
+				# HELP kube_pod_chaoskube_enabled Describes whether the pod can be killed by chaoskube
+				# TYPE kube_pod_chaoskube_enabled gauge
+				kube_pod_chaoskube_enabled{namespace="ns1",pod="pod1",pod_chaoskube_enabled="true"} 1
+		`,
+			MetricNames: []string{
+				"kube_pod_chaoskube_enabled",
+			},
+		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "ns1",
+					Annotations: map[string]string{
+						"chaos.alpha.kubernetes.io/enabled": "false",
+					},
+				},
+				Spec: v1.PodSpec{},
+			},
+			Want: `
+				# HELP kube_pod_chaoskube_enabled Describes whether the pod can be killed by chaoskube
+				# TYPE kube_pod_chaoskube_enabled gauge
+				kube_pod_chaoskube_enabled{namespace="ns1",pod="pod1",pod_chaoskube_enabled="false"} 0
+		`,
+			MetricNames: []string{
+				"kube_pod_chaoskube_enabled",
+			},
+		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "ns1",
+				},
+				Spec: v1.PodSpec{},
+			},
+			Want: `
+				# HELP kube_pod_chaoskube_enabled Describes whether the pod can be killed by chaoskube
+				# TYPE kube_pod_chaoskube_enabled gauge
+				kube_pod_chaoskube_enabled{namespace="ns1",pod="pod1",pod_chaoskube_enabled="false"} 0
+		`,
+			MetricNames: []string{
+				"kube_pod_chaoskube_enabled",
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/main_test.go
+++ b/main_test.go
@@ -172,6 +172,12 @@ kube_pod_created{namespace="default",pod="pod0"} 1.5e+09
 # HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
 # TYPE kube_pod_restart_policy gauge
 kube_pod_restart_policy{namespace="default",pod="pod0",type="Always"} 1
+# HELP kube_pod_security_policy Describes the pod security policy in use by this pod.
+# TYPE kube_pod_security_policy gauge
+kube_pod_security_policy{namespace="default",pod="pod0",pod_security_policy=""} 1
+# HELP kube_pod_chaoskube_enabled Describes whether the pod can be killed by chaoskube
+# TYPE kube_pod_chaoskube_enabled gauge
+kube_pod_chaoskube_enabled{namespace="default",pod="pod0",pod_chaoskube_enabled="false"} 0
 # HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
 # TYPE kube_pod_status_scheduled_time gauge
 # HELP kube_pod_status_phase The pods current phase.


### PR DESCRIPTION
**What this PR does / why we need it**: use chaoskube annotation to create a monitor for pods with chaos disabled

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: https://www.pivotaltracker.com/n/projects/2476294/stories/162002649

